### PR TITLE
Ensure non-string attribute value does not crash creation

### DIFF
--- a/src/dynatrace/metric/utils/__init__.py
+++ b/src/dynatrace/metric/utils/__init__.py
@@ -22,4 +22,4 @@ from .metric_error import MetricError  # noqa: F401
 from .dynatrace_metrics_api_constants import \
     DynatraceMetricsApiConstants  # noqa: F401
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/src/dynatrace/metric/utils/_normalize.py
+++ b/src/dynatrace/metric/utils/_normalize.py
@@ -129,6 +129,7 @@ class Normalize:
             # will be serialized.
             return ""
 
+        dimension_value = str(dimension_value)
         dimension_value = dimension_value[:self.__dv_max_length]
 
         return self.__replace_control_characters(dimension_value)

--- a/src/dynatrace/metric/utils/_normalize.py
+++ b/src/dynatrace/metric/utils/_normalize.py
@@ -16,6 +16,7 @@ import logging
 import re
 import unicodedata
 from typing import Mapping, Optional
+from .metric_error import MetricError
 
 
 class Normalize:
@@ -67,6 +68,10 @@ class Normalize:
         if not metric_key:
             return None
 
+        if not isinstance(metric_key, str):
+            raise MetricError(
+                f"Unexpected metric key type: {type(metric_key)}")
+
         # trim if too long
         metric_key = metric_key[:self.__mk_max_length]
 
@@ -102,6 +107,10 @@ class Normalize:
         if not dimension_key:
             return None
 
+        if not isinstance(dimension_key, str):
+            raise MetricError(
+                f"Unexpected dimension key type: {type(dimension_key)}")
+
         dimension_key = dimension_key[:self.__dk_max_length]
 
         sections = list(filter(None, map(
@@ -129,7 +138,9 @@ class Normalize:
             # will be serialized.
             return ""
 
-        dimension_value = str(dimension_value)
+        if not isinstance(dimension_value, str):
+            raise MetricError(
+                f"Unexpected dimension value type: {type(dimension_value)}")
         dimension_value = dimension_value[:self.__dv_max_length]
 
         return self.__replace_control_characters(dimension_value)

--- a/tests/test_normalize_parametrized.py
+++ b/tests/test_normalize_parametrized.py
@@ -223,7 +223,7 @@ cases_stringify_dimension_values = [
     ("bool", True, "True"),
     ("int array", [1, 2, 3], "[1, 2, 3]"),
     ("float array", [1.2, 2.3, 3.4], "[1.2, 2.3, 3.4]"),
-    ("int array", [True, False, True], "[True, False, True]"),
+    ("bool array", [True, False, True], "[True, False, True]"),
 ]
 
 

--- a/tests/test_normalize_parametrized.py
+++ b/tests/test_normalize_parametrized.py
@@ -215,3 +215,19 @@ cases_escape_dimension_values = [
                          ids=[x[0] for x in cases_escape_dimension_values])
 def test_parametrized_escape_dimension_value(msg, inp, exp):
     assert normalizer.escape_dimension_value(inp) == exp
+
+
+cases_stringify_dimension_values = [
+    ("int", 1, "1"),
+    ("float", 2.3, "2.3"),
+    ("bool", True, "True"),
+    ("int array", [1, 2, 3], "[1, 2, 3]"),
+    ("float array", [1.2, 2.3, 3.4], "[1.2, 2.3, 3.4]"),
+    ("int array", [True, False, True], "[True, False, True]"),
+]
+
+
+@pytest.mark.parametrize("msg,inp,exp", cases_stringify_dimension_values,
+                         ids=[x[0] for x in cases_stringify_dimension_values])
+def test_parametrized_stringify_dimension_value(msg, inp, exp):
+    assert normalizer.normalize_dimension_value(inp) == exp

--- a/tests/test_normalize_parametrized.py
+++ b/tests/test_normalize_parametrized.py
@@ -12,9 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import unittest
-
 import pytest
+from dynatrace.metric.utils import MetricError
 from dynatrace.metric.utils._normalize import Normalize
 
 normalizer = Normalize()
@@ -217,17 +216,38 @@ def test_parametrized_escape_dimension_value(msg, inp, exp):
     assert normalizer.escape_dimension_value(inp) == exp
 
 
-cases_stringify_dimension_values = [
-    ("int", 1, "1"),
-    ("float", 2.3, "2.3"),
-    ("bool", True, "True"),
-    ("int array", [1, 2, 3], "[1, 2, 3]"),
-    ("float array", [1.2, 2.3, 3.4], "[1.2, 2.3, 3.4]"),
-    ("bool array", [True, False, True], "[True, False, True]"),
+cases_invalid_type = [
+    ("int", 1),
+    ("float", 2.3),
+    ("bool", True),
+    ("int array", [1, 2, 3]),
+    ("float array", [1.2, 2.3, 3.4]),
+    ("bool array", [True, False, True]),
 ]
 
 
-@pytest.mark.parametrize("msg,inp,exp", cases_stringify_dimension_values,
-                         ids=[x[0] for x in cases_stringify_dimension_values])
-def test_parametrized_stringify_dimension_value(msg, inp, exp):
-    assert normalizer.normalize_dimension_value(inp) == exp
+@pytest.mark.parametrize("msg,inp", cases_invalid_type,
+                         ids=[x[0] for x in cases_invalid_type])
+def test_parametrized_invalid_dimension_value_type(msg, inp):
+    with pytest.raises(MetricError) as ex:
+        normalizer.normalize_dimension_value(inp)
+
+    assert str(ex.value) == f"Unexpected dimension value type: {type(inp)}"
+
+
+@pytest.mark.parametrize("msg,inp", cases_invalid_type,
+                         ids=[x[0] for x in cases_invalid_type])
+def test_parametrized_invalid_dimension_key_type(msg, inp):
+    with pytest.raises(MetricError) as ex:
+        normalizer.normalize_dimension_key(inp)
+
+    assert str(ex.value) == f"Unexpected dimension key type: {type(inp)}"
+
+
+@pytest.mark.parametrize("msg,inp", cases_invalid_type,
+                         ids=[x[0] for x in cases_invalid_type])
+def test_parametrized_invalid_metric_key_type(msg, inp):
+    with pytest.raises(MetricError) as ex:
+        normalizer.normalize_metric_key(inp)
+
+    assert str(ex.value) == f"Unexpected metric key type: {type(inp)}"


### PR DESCRIPTION
Non-string values should never reach this part of the code, but the python type hints are just hints, so it's possible still. 

Not sure whether I should also check the same for dimension keys / metric keys.